### PR TITLE
We have a tool to run a body only once, use it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.14.1 / 2023-12-05
+- Fix bug that allowed a leaf body to be run multiple times in engines which used the lazy environment.
+
 ## 1.14.0 / 2023-11-30
 - Fix bug preventing nil values to the passed through channels on core-async applicative engine
 - Create a blocking tag that allows leafs and sequences to be tagged with blocking to signal that they contain a blocking IO or other expensive blocking op. Engines can choose to optimize runs with this info

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject dev.nu/nodely "1.14.0"
+(defproject dev.nu/nodely "1.14.1"
   :description "Decoupling data fetching from data dependency declaration"
   :url "https://github.com/nubank/nodely"
   :license {:name "MIT"}


### PR DESCRIPTION
`dosync` does not create an exclusion context on executing its body, so it's possible for two threads to enter the `dosync` and try to run `eval-fn` independently. Only one of them will win and get into `ref-map`, but there's still two outbound requests. This is bad.

Delay actually promises exactly once execution and deferred execution, which are the two things we want. Makes sure that locks are localized on individual bodies and we don't e.g. lock on the entire map.

This is aimed as resolving @joaopluigi 's reported problem of requests firing multiple times.