### PR TITLE
Allow running the sync engine with a return on a channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.15.0 / 2023-12-07
+- Allow running the lazy synchronous engine with a channel return.
+
 ## 1.14.1 / 2023-12-05
 - Fix bug that allowed a leaf body to be run multiple times in engines which used the lazy environment.
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject dev.nu/nodely "1.14.1"
+(defproject dev.nu/nodely "1.15.0"
   :description "Decoupling data fetching from data dependency declaration"
   :url "https://github.com/nubank/nodely"
   :license {:name "MIT"}

--- a/src/nodely/api/v0.clj
+++ b/src/nodely/api/v0.clj
@@ -68,6 +68,7 @@
            :or    {engine :core-async.lazy-scheduling}
            :as    opts}]
    (case engine
+     :sync.lazy                  (nodely.engine.lazy/eval-key-channel env k)
      :core-async.lazy-scheduling (lazy-scheduling/eval-key-channel env k opts)
      :applicative.core-async     (nodely.engine.applicative/eval-key-contextual env k (assoc opts ::applicative/context applicative.core-async/context)))))
 

--- a/src/nodely/engine/lazy.clj
+++ b/src/nodely/engine/lazy.clj
@@ -1,6 +1,7 @@
 (ns nodely.engine.lazy
   (:refer-clojure :exclude [eval resolve])
   (:require
+   [clojure.core.async :as async]
    [nodely.data :as data]
    [nodely.engine.core :as core]))
 
@@ -11,6 +12,10 @@
 (defn eval-key
   [env k]
   (data/get-value (eval env k) k))
+
+(defn eval-key-channel
+  [env k]
+  (async/thread (eval-key env k)))
 
 (defn eval-node
   [node env]

--- a/test/nodely/api_test.clj
+++ b/test/nodely/api_test.clj
@@ -1,7 +1,21 @@
 (ns nodely.api-test
   (:refer-clojure :exclude [cond])
   (:require
-   [clojure.test :refer :all]))
+   [clojure.core.async :as async]
+   [clojure.test :refer :all]
+   [nodely.api.v0 :as api :refer [>value >leaf eval-key-channel]]))
+
+(def env {:x (>value 2)
+          :y (>value 3)
+          :z (>leaf (+ ?x ?y))})
+
+(deftest eval-key-channel-test
+  (testing "returning a result to a channel with :sync.lazy"
+    (is (= 5 (async/<!! (eval-key-channel env :z {::api/engine :sync.lazy})))))
+  (testing "returning a result to a channel with :core-async.lazy-scheduling"
+    (is (= 5 (async/<!! (eval-key-channel env :z {::api/engine :core-async.lazy-scheduling})))))
+  (testing "returning a result to a channel with :applicative.core-async"
+    (is (= 5 (async/<!! (eval-key-channel env :z {::api/engine :applicative.core-async}))))))
 
 #_(deftest nested-cond-macros
     (testing "using internal variables"

--- a/test/nodely/api_test.clj
+++ b/test/nodely/api_test.clj
@@ -3,7 +3,7 @@
   (:require
    [clojure.core.async :as async]
    [clojure.test :refer :all]
-   [nodely.api.v0 :as api :refer [>value >leaf eval-key-channel]]))
+   [nodely.api.v0 :as api :refer [>leaf >value eval-key-channel]]))
 
 (def env {:x (>value 2)
           :y (>value 3)

--- a/test/nodely/engine/lazy_test.clj
+++ b/test/nodely/engine/lazy_test.clj
@@ -1,6 +1,7 @@
 (ns nodely.engine.lazy-test
   (:refer-clojure :exclude [eval resolve])
   (:require
+   [clojure.core.async :as async]
    [clojure.test :refer :all]
    [matcher-combinators.test :refer [match?]]
    [nodely.data :as data]
@@ -27,3 +28,17 @@
                                                                       (+ x y))))
                                             {:x 2
                                              :y 3})))))
+
+(def eval-key-channel-env {:x (data/value 2)
+                           :y (data/value 3)
+                           :z (data/branch (data/leaf [:x] (fn [{:keys [x]}] (odd? x)))
+                                           (data/value :odd)
+                                           (data/leaf [:y :x]
+                                                      (fn [{:keys [x y]}]
+                                                        (+ x y))))})
+
+(deftest eval-key-channel
+  (testing "eval and getting a channel back"
+    (is (match? 5
+                (async/<!!
+                 (lazy/eval-key-channel eval-key-channel-env :z))))))


### PR DESCRIPTION
Callers to Nodely (such as Pedestal handlers) want to normalize on an interface of consistently dealing in e.g. channels.


While we cannot provide all the values that come with running with core.async when using the lazy synchronous engine, we can certainly provide interface parity, so that client code can be agnostic beyond which engine it selects, about how Nodely will operate.

Creates an interfaces on the lazy synchronous engine that returns a channel, and conducts evaluation in the core.async thread dispatch pool (not the callback dispatch pool where blocking is forbidden)