### PR TITLE
Closure sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
-## Unreleased
-- Better error message for sync lazy engine when env is missing a key
+## 1.16.0 / 2024-02-16
+- Allow sequences to refer to any node in the environment for the mapped fn
 
 ## 1.15.0 / 2023-12-07
 - Allow running the lazy synchronous engine with a channel return.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject dev.nu/nodely "1.15.0"
+(defproject dev.nu/nodely "1.16.0"
   :description "Decoupling data fetching from data dependency declaration"
   :url "https://github.com/nubank/nodely"
   :license {:name "MIT"}

--- a/src/nodely/data.clj
+++ b/src/nodely/data.clj
@@ -24,12 +24,10 @@
                         :truthy    (s/recursive #'Node)
                         :falsey    (s/recursive #'Node)})
 
-(s/defschema Sequence #::{:type  (s/eq :sequence)
-                          :input s/Keyword
-                          :fn    (s/conditional
-                                  #(= (get % ::type) :leaf) Leaf
-                                  ifn? (s/pred ifn?))
-                          :tags  #{node-tag}})
+(s/defschema Sequence #::{:type         (s/eq :sequence)
+                          :input        s/Keyword
+                          :process-node (s/recursive #'Node)
+                          :tags         #{node-tag}})
 
 (s/defschema Node (s/conditional
                    #(= (get % ::type) :value) Value
@@ -76,18 +74,18 @@
   ([input :- s/Keyword
     f
     tags :- #{node-tag}]
-   #::{:type  :sequence
-       :input input
-       :fn    f
-       :tags  tags})
+   #::{:type         :sequence
+       :input        input
+       :process-node (value f)
+       :tags         tags})
   ([input :- s/Keyword
     closure-inputs
     f
     tags :- #{node-tag}]
-   #::{:type           :sequence
-       :input          input
-       :fn             (leaf closure-inputs f)
-       :tags           tags}))
+   #::{:type         :sequence
+       :input        input
+       :process-node (leaf closure-inputs f)
+       :tags         tags}))
 
 ;;
 ;; Node Utilities

--- a/src/nodely/data.clj
+++ b/src/nodely/data.clj
@@ -27,7 +27,9 @@
 
 (s/defschema Sequence #::{:type         (s/eq :sequence)
                           :input        s/Keyword
-                          :process-node (s/recursive #'Node)
+                          :process-node (s/conditional
+                                         #(= (get % ::type) :value) Value
+                                         #(= (get % ::type) :leaf) Leaf)
                           :tags         #{node-tag}})
 
 (s/defschema Node (s/conditional

--- a/src/nodely/data.clj
+++ b/src/nodely/data.clj
@@ -24,10 +24,15 @@
                         :truthy    (s/recursive #'Node)
                         :falsey    (s/recursive #'Node)})
 
-(s/defschema Sequence #::{:type  (s/eq :sequence)
-                          :input s/Keyword
-                          :fn    (s/pred ifn?)
-                          :tags  #{node-tag}})
+(s/defschema Sequence (s/either #::{:type  (s/eq :sequence)
+                                    :input s/Keyword
+                                    :fn    (s/pred ifn?)
+                                    :tags  #{node-tag}}
+                                #::{:type           (s/eq :sequence)
+                                    :input          s/Keyword
+                                    :closure-inputs #{s/Keyword}
+                                    :fn-fn          (s/pred ifn?)
+                                    :tags  #{node-tag}}))
 
 (s/defschema Node (s/conditional
                    #(= (get % ::type) :value) Value
@@ -69,14 +74,15 @@
 
 (s/defn sequence
   ([input :- s/Keyword
-    fn]
-   (sequence input fn #{}))
+    f]
+   (sequence input f #{}))
   ([input :- s/Keyword
-    fn
+    f
     tags :- #{node-tag}]
    #::{:type  :sequence
        :input input
-       :fn    fn
+       :closure-inputs #{}
+       :fn-fn (fn [env-deps] f)
        :tags  tags}))
 
 ;;

--- a/src/nodely/data.clj
+++ b/src/nodely/data.clj
@@ -1,7 +1,8 @@
 (ns nodely.data
   (:refer-clojure :exclude [map sequence])
   (:require
-   [schema.core :as s]))
+   [schema.core :as s]
+   [clojure.set :as set]))
 
 ;;
 ;; Node Definitions
@@ -103,12 +104,15 @@
   (= :leaf (::type node)))
 
 (defn node-inputs
-  [node]
-  (case (::type node)
-    :value    #{}
-    :leaf     (::inputs node)
-    :branch   (recur (::condition node))
-    :sequence #{(::input node)}))
+  ([node]
+   (node-inputs node #{}))
+  ([node inputs]
+   (case (::type node)
+     :value    inputs
+     :leaf     (set/union inputs (::inputs node))
+     :branch   (recur (::condition node) inputs)
+     :sequence (recur (::process-node node)
+                      (conj inputs (::input node))))))
 
 ;;
 ;; Env Utils

--- a/src/nodely/data.clj
+++ b/src/nodely/data.clj
@@ -24,15 +24,12 @@
                         :truthy    (s/recursive #'Node)
                         :falsey    (s/recursive #'Node)})
 
-(s/defschema Sequence (s/either #::{:type  (s/eq :sequence)
-                                    :input s/Keyword
-                                    :fn    (s/pred ifn?)
-                                    :tags  #{node-tag}}
-                                #::{:type           (s/eq :sequence)
-                                    :input          s/Keyword
-                                    :closure-inputs [s/Keyword]
-                                    :fn-fn          (s/pred ifn?)
-                                    :tags  #{node-tag}}))
+(s/defschema Sequence #::{:type  (s/eq :sequence)
+                          :input s/Keyword
+                          :fn    (s/conditional
+                                  #(= (get % ::type) :leaf) Leaf
+                                  ifn? (s/pred ifn?))
+                          :tags  #{node-tag}})
 
 (s/defschema Node (s/conditional
                    #(= (get % ::type) :value) Value
@@ -89,8 +86,7 @@
     tags :- #{node-tag}]
    #::{:type           :sequence
        :input          input
-       :closure-inputs closure-inputs
-       :fn-fn          f
+       :fn             (leaf closure-inputs f)
        :tags           tags}))
 
 ;;
@@ -103,6 +99,10 @@
 (defn value?
   [node]
   (= :value (::type node)))
+
+(defn leaf?
+  [node]
+  (= :leaf (::type node)))
 
 (defn node-inputs
   [node]

--- a/src/nodely/data.clj
+++ b/src/nodely/data.clj
@@ -30,7 +30,7 @@
                                     :tags  #{node-tag}}
                                 #::{:type           (s/eq :sequence)
                                     :input          s/Keyword
-                                    :closure-inputs #{s/Keyword}
+                                    :closure-inputs [s/Keyword]
                                     :fn-fn          (s/pred ifn?)
                                     :tags  #{node-tag}}))
 
@@ -81,9 +81,17 @@
     tags :- #{node-tag}]
    #::{:type  :sequence
        :input input
-       :closure-inputs #{}
-       :fn-fn (fn [env-deps] f)
-       :tags  tags}))
+       :fn    f
+       :tags  tags})
+  ([input :- s/Keyword
+    closure-inputs
+    f
+    tags :- #{node-tag}]
+   #::{:type           :sequence
+       :input          input
+       :closure-inputs closure-inputs
+       :fn-fn          f
+       :tags           tags}))
 
 ;;
 ;; Node Utilities

--- a/src/nodely/data.clj
+++ b/src/nodely/data.clj
@@ -1,8 +1,8 @@
 (ns nodely.data
   (:refer-clojure :exclude [map sequence])
   (:require
-   [schema.core :as s]
-   [clojure.set :as set]))
+   [clojure.set :as set]
+   [schema.core :as s]))
 
 ;;
 ;; Node Definitions

--- a/src/nodely/engine/applicative.clj
+++ b/src/nodely/engine/applicative.clj
@@ -24,10 +24,20 @@
 
 (declare eval-node)
 
+(defn applicative-sequence-fn
+  ;; monadic context of node
+  ;; map of keyword -> monadic context of lazy-env
+
+  ;; monadic context of a function of one argument out
+  [node lazy-env]
+  (m/pure (or (::data/fn node)
+              ((::data/fn-fn node)
+               (into {} (map (juxt identity (comp ::data/value m/extract (partial get lazy-env))) (::data/closure-inputs node)))))))
+
 (defn eval-sequence
   [node lazy-env opts]
   (let [in-key (::data/input node)]
-    (m/alet [f         (m/pure (core/sequence-fn node lazy-env))
+    (m/alet [f         (applicative-sequence-fn node lazy-env) ;;(m/pure (core/sequence-fn node lazy-env))
              input-seq (get lazy-env in-key)
              result    (sequence (map (fn [x] (m/fmap f (m/pure x)))
                                       (::data/value input-seq)))]

--- a/src/nodely/engine/applicative.clj
+++ b/src/nodely/engine/applicative.clj
@@ -26,11 +26,11 @@
 
 (defn eval-sequence
   [node lazy-env opts]
-  (let [f  (::data/fn node)
-        in-key (::data/input node)]
-    (m/alet [input-seq (get lazy-env in-key)
-             result (sequence (map (fn [x] (m/fmap f (m/pure x)))
-                                   (::data/value input-seq)))]
+  (let [in-key (::data/input node)]
+    (m/alet [f         (m/pure (core/sequence-fn node lazy-env))
+             input-seq (get lazy-env in-key)
+             result    (sequence (map (fn [x] (m/fmap f (m/pure x)))
+                                      (::data/value input-seq)))]
             (data/value result))))
 
 (defn eval-branch

--- a/src/nodely/engine/applicative.clj
+++ b/src/nodely/engine/applicative.clj
@@ -24,17 +24,11 @@
 
 (declare eval-node)
 
-(defn applicative-sequence-fn
-  [node lazy-env opts]
-  (let [f (::data/fn node)]
-    (if (data/leaf? f)
-      (m/fmap ::data/value (eval-node f lazy-env opts))
-      (m/pure f))))
-
 (defn eval-sequence
   [node lazy-env opts]
   (let [in-key (::data/input node)
-        mf     (applicative-sequence-fn node lazy-env opts)
+        mf     (m/fmap ::data/value
+                       (eval-node (::data/process-node node) lazy-env opts))
         mseq   (get lazy-env in-key)]
     (->> mseq
          (m/fmap (comp m/sequence

--- a/src/nodely/engine/applicative.clj
+++ b/src/nodely/engine/applicative.clj
@@ -25,17 +25,16 @@
 (declare eval-node)
 
 (defn applicative-sequence-fn
-  [node lazy-env]
-  (or (when-let [f (::data/fn node)]
-        (m/pure f))
-      (let [ks (::data/closure-inputs node)]
-        (m/fmap #((::data/fn-fn node) (zipmap ks (map ::data/value %)))
-                (m/sequence (map (partial get lazy-env) ks))))))
+  [node lazy-env opts]
+  (let [f (::data/fn node)]
+    (if (data/leaf? f)
+      (m/fmap ::data/value (eval-node f lazy-env opts))
+      (m/pure f))))
 
 (defn eval-sequence
   [node lazy-env opts]
   (let [in-key (::data/input node)
-        mf     (applicative-sequence-fn node lazy-env)
+        mf     (applicative-sequence-fn node lazy-env opts)
         mseq   (get lazy-env in-key)]
     (->> mseq
          (m/fmap (comp m/sequence

--- a/src/nodely/engine/core.clj
+++ b/src/nodely/engine/core.clj
@@ -123,17 +123,10 @@
   [k env]
   (resolve k (resolve-one-branch k env)))
 
-(defn sequence-fn
-  ([node env]
-   (let [f (::data/fn node)]
-     (if (data/leaf? f)
-       (::data/value (first (leaf->value f env)))
-       f))))
-
 (defn- sequence->value
   [node env]
   (let [in-key  (::data/input node)
-        f       (sequence-fn node env)
+        f       (::data/value (first (node->value (::data/process-node node) env)))
         new-env (resolve-inputs [in-key] env)
         in      (data/get-value new-env in-key)]
     [(data/value (mapv f in)) new-env]))

--- a/src/nodely/engine/core.clj
+++ b/src/nodely/engine/core.clj
@@ -125,10 +125,10 @@
 
 (defn sequence-fn
   ([node env]
-   (sequence-fn prepare-inputs node env))
-  ([inputs-fn node env]
-   (or (::data/fn node)
-       ((::data/fn-fn node) (inputs-fn (::data/closure-inputs node) env)))))
+   (let [f (::data/fn node)]
+     (if (data/leaf? f)
+       (::data/value (first (leaf->value f env)))
+       f))))
 
 (defn- sequence->value
   [node env]

--- a/src/nodely/engine/core.clj
+++ b/src/nodely/engine/core.clj
@@ -123,11 +123,17 @@
   [k env]
   (resolve k (resolve-one-branch k env)))
 
+(defn sequence-fn
+  ([node env]
+   (sequence-fn prepare-inputs node env))
+  ([inputs-fn node env]
+   (or (::data/fn node)
+       ((::data/fn-fn node) (inputs-fn (::data/closure-inputs node) env)))))
+
 (defn- sequence->value
   [node env]
   (let [in-key  (::data/input node)
-        f       (or (::data/fn node)
-                    ((::data/fn-fn node) (prepare-inputs (::data/closure-inputs node) env)))
+        f       (sequence-fn node env)
         new-env (resolve-inputs [in-key] env)
         in      (data/get-value new-env in-key)]
     [(data/value (mapv f in)) new-env]))

--- a/src/nodely/engine/core.clj
+++ b/src/nodely/engine/core.clj
@@ -126,7 +126,8 @@
 (defn- sequence->value
   [node env]
   (let [in-key  (::data/input node)
-        f       (::data/fn node)
+        f       (or (::data/fn node)
+                    ((::data/fn-fn node) (prepare-inputs (::data/closure-inputs node) env)))
         new-env (resolve-inputs [in-key] env)
         in      (data/get-value new-env in-key)]
     [(data/value (mapv f in)) new-env]))

--- a/src/nodely/engine/core.clj
+++ b/src/nodely/engine/core.clj
@@ -76,8 +76,8 @@
 
 (defn prepare-inputs
   [input-keys env]
-  (->> (select-keys env input-keys)
-       (map (juxt key (comp ::data/value val)))
+  (->> input-keys
+       (map (juxt identity (comp ::data/value (partial get env))))
        (into {})))
 
 (defn eval-leaf

--- a/src/nodely/engine/core_async/iterative_scheduling.clj
+++ b/src/nodely/engine/core_async/iterative_scheduling.clj
@@ -15,7 +15,7 @@
   [node resolved-env {::keys [max-sequence-parallelism]
                       :or    {max-sequence-parallelism 4}}]
   (let [in-key          (::data/input node)
-        f               (core/sequence-fn node resolved-env)
+        f               (::data/value (first (core/node->value (::data/process-node node) resolved-env)))
         sequence        (map data/value (get (core/prepare-inputs [in-key] resolved-env) in-key))
         in-chan         (async/to-chan! sequence)
         pipeline-result (async/chan)]

--- a/src/nodely/engine/core_async/iterative_scheduling.clj
+++ b/src/nodely/engine/core_async/iterative_scheduling.clj
@@ -15,7 +15,7 @@
   [node resolved-env {::keys [max-sequence-parallelism]
                       :or    {max-sequence-parallelism 4}}]
   (let [in-key          (::data/input node)
-        f               (::data/fn node)
+        f               (core/sequence-fn node resolved-env)
         sequence        (map data/value (get (core/prepare-inputs [in-key] resolved-env) in-key))
         in-chan         (async/to-chan! sequence)
         pipeline-result (async/chan)]

--- a/src/nodely/engine/core_async/lazy_scheduling.clj
+++ b/src/nodely/engine/core_async/lazy_scheduling.clj
@@ -14,7 +14,7 @@
 (defn async-sequence-fn
   [node lazy-env]
   (async/go
-    (or (:data/fn node)
+    (or (::data/fn node)
         ((::data/fn-fn node)
          (loop [[cur & pending] (::data/closure-inputs node)
                 res {}]

--- a/src/nodely/engine/core_async/lazy_scheduling.clj
+++ b/src/nodely/engine/core_async/lazy_scheduling.clj
@@ -19,7 +19,7 @@
          (loop [[cur & pending] (::data/closure-inputs node)
                 res {}]
            (if cur
-             (recur pending (assoc res cur (async/<! (get lazy-env cur))))
+             (recur pending (assoc res cur (::data/value (async/<! (get lazy-env cur)))))
              res))))))
 
 (defn eval-sequence

--- a/src/nodely/engine/manifold.clj
+++ b/src/nodely/engine/manifold.clj
@@ -20,7 +20,7 @@
 (defn eval-sequence
   [node future-env]
   (let [in-key (::data/input node)
-        f      (::data/fn node)
+        f      (core/sequence-fn prepare-inputs node future-env)
         in     (prepare-inputs [in-key] future-env)]
     (data/value (->> (get in in-key)
                      (mapv #(deferred/future (f %)))

--- a/src/nodely/engine/manifold.clj
+++ b/src/nodely/engine/manifold.clj
@@ -6,6 +6,8 @@
    [nodely.data :as data]
    [nodely.engine.core :as core]))
 
+(declare eval-async)
+
 (defn- prepare-inputs
   [input-keys future-env]
   (->> (select-keys future-env input-keys)
@@ -17,17 +19,10 @@
   (let [in (prepare-inputs (::data/inputs node) future-env)]
     (core/eval-leaf node in)))
 
-(defn sequence-fn
-  [node future-env]
-  (let [f (::data/fn node)]
-    (if (data/leaf? f)
-      (::data/value (eval-leaf f future-env))
-      f)))
-
 (defn eval-sequence
   [node future-env]
   (let [in-key (::data/input node)
-        f      (sequence-fn node future-env)
+        f      (::data/value (eval-async (::data/process-node node) future-env))
         in     (prepare-inputs [in-key] future-env)]
     (data/value (->> (get in in-key)
                      (mapv #(deferred/future (f %)))

--- a/src/nodely/engine/manifold.clj
+++ b/src/nodely/engine/manifold.clj
@@ -17,10 +17,17 @@
   (let [in (prepare-inputs (::data/inputs node) future-env)]
     (core/eval-leaf node in)))
 
+(defn sequence-fn
+  [node future-env]
+  (let [f (::data/fn node)]
+    (if (data/leaf? f)
+      (::data/value (eval-leaf f future-env))
+      f)))
+
 (defn eval-sequence
   [node future-env]
   (let [in-key (::data/input node)
-        f      (core/sequence-fn prepare-inputs node future-env)
+        f      (sequence-fn node future-env)
         in     (prepare-inputs [in-key] future-env)]
     (data/value (->> (get in in-key)
                      (mapv #(deferred/future (f %)))

--- a/src/nodely/syntax.clj
+++ b/src/nodely/syntax.clj
@@ -36,8 +36,12 @@
     (data/value n)))
 
 (defmacro >sequence
-  [fn input]
-  (list `data/sequence (question-mark->keyword input) fn))
+  [f input]
+  (let [symbols-to-be-replaced (question-mark-symbols f)
+        closure-inputs (mapv question-mark->keyword symbols-to-be-replaced)
+        fn-fn (fn-with-arg-map symbols-to-be-replaced f)]
+    (assert-not-shadowing! symbols-to-be-replaced)
+    `(data/sequence ~(question-mark->keyword input) ~closure-inputs ~fn-fn #{})))
 
 (defmacro >leaf
   [expr]

--- a/src/nodely/syntax.clj
+++ b/src/nodely/syntax.clj
@@ -41,7 +41,9 @@
         closure-inputs (mapv question-mark->keyword symbols-to-be-replaced)
         fn-fn (fn-with-arg-map symbols-to-be-replaced f)]
     (assert-not-shadowing! symbols-to-be-replaced)
-    `(data/sequence ~(question-mark->keyword input) ~closure-inputs ~fn-fn #{})))
+    (if (seq symbols-to-be-replaced)
+      `(data/sequence ~(question-mark->keyword input) ~closure-inputs ~fn-fn #{})
+      `(data/sequence ~(question-mark->keyword input) ~f #{}))))
 
 (defmacro >leaf
   [expr]

--- a/test/nodely/engine/applicative_test.clj
+++ b/test/nodely/engine/applicative_test.clj
@@ -16,7 +16,7 @@
    [nodely.engine.core-async.core :as nodely.async]
    [nodely.engine.schema :as schema]
    [nodely.fixtures :as fixtures]
-   [nodely.syntax :as syntax :refer [>leaf >value >sequence]]
+   [nodely.syntax :as syntax :refer [>leaf >sequence >value]]
    [nodely.syntax.schema :refer [yielding-schema]]
    [promesa.core :as p]
    [schema.core :as s]))

--- a/test/nodely/engine/applicative_test.clj
+++ b/test/nodely/engine/applicative_test.clj
@@ -16,7 +16,7 @@
    [nodely.engine.core-async.core :as nodely.async]
    [nodely.engine.schema :as schema]
    [nodely.fixtures :as fixtures]
-   [nodely.syntax :as syntax :refer [>leaf >value]]
+   [nodely.syntax :as syntax :refer [>leaf >value >sequence]]
    [nodely.syntax.schema :refer [yielding-schema]]
    [promesa.core :as p]
    [schema.core :as s]))
@@ -73,6 +73,10 @@
 
 (def env-with-sequence {:a (>leaf [1 2 3])
                         :b (syntax/>sequence inc ?a)})
+
+(def env-with-closure-sequence {:x (data/value [1 2 3])
+                                :z (data/value 2)
+                                :y (>sequence (fn [e] (* e ?z)) ?x)})
 
 (def env+sequence-with-nil-values
   {:a (>leaf [1 2 nil 4])
@@ -175,7 +179,10 @@
       (is (match? (matchers/within-delta 8000000 2000000000)
                   (- nanosec-sync nanosec-async)))))
   (testing "Actually computes the correct answers"
-    (is (match? [2 3 4] (applicative/eval-key env-with-sequence+delay :c)))))
+    (is (match? [2 3 4] (applicative/eval-key env-with-sequence+delay :c))))
+  (testing "resolve closure sequence"
+    (is (= [2 4 6]
+           (applicative/eval-key env-with-closure-sequence :y)))))
 
 (deftest schema-test
   (let [env-with-schema         {:a (>value 2)

--- a/test/nodely/engine/applicative_test.clj
+++ b/test/nodely/engine/applicative_test.clj
@@ -76,7 +76,7 @@
 
 (def env-with-closure-sequence {:x (data/value [1 2 3])
                                 :z (data/value 2)
-                                :y (>sequence (fn [e] (* e ?z)) ?x)})
+                                :y (>sequence #(* % ?z) ?x)})
 
 (def env+sequence-with-nil-values
   {:a (>leaf [1 2 nil 4])

--- a/test/nodely/engine/core_async/lazy_scheduling_test.clj
+++ b/test/nodely/engine/core_async/lazy_scheduling_test.clj
@@ -14,7 +14,7 @@
    [nodely.engine.core-async.lazy-scheduling :as nasync]
    [nodely.engine.lazy :as engine.lazy]
    [nodely.fixtures :as fixtures]
-   [nodely.syntax :as syntax :refer [>cond >leaf >value >sequence blocking]]))
+   [nodely.syntax :as syntax :refer [>cond >leaf >sequence >value blocking]]))
 
 (def test-env {:a (>leaf (+ 1 2))
                :b (>leaf (* ?a 2))

--- a/test/nodely/engine/core_async/lazy_scheduling_test.clj
+++ b/test/nodely/engine/core_async/lazy_scheduling_test.clj
@@ -59,9 +59,9 @@
 (def env-with-sequence {:a (>leaf [1 2 3])
                         :b (>sequence inc ?a)})
 
-(def env-with-closure-sequence {:a (>leaf [1 2 3])
+(def env-with-closure-sequence {:a (>value [1 2 3])
                                 :c (>value 2)
-                                :b (>sequence #(* % ?c) ?a)})
+                                :b (>sequence (fn [e] (* e ?c)) ?a)})
 
 (def env+sequence-with-nil-values
   {:a (>leaf [1 2 nil 4])
@@ -146,9 +146,9 @@
       (is (match? (matchers/within-delta 8000000 2000000000)
                   (- nanosec-sync nanosec-async)))))
   (testing "Actually computes the correct answers"
-    (is (= [2 3 4] (nasync/eval-key env-with-sequence+delay :b))))
+    (is (match? [2 3 4] (nasync/eval-key env-with-sequence+delay :b))))
   (testing "When there's a closure in the sequence expr"
-    (is (= [2 4 6] (nasync/eval-key env-with-closure-sequence :b)))))
+    (is (match? [2 4 6] (nasync/eval-key env-with-closure-sequence :b)))))
 
 (deftest eval-test
   (testing "eval node async"

--- a/test/nodely/engine/core_test.clj
+++ b/test/nodely/engine/core_test.clj
@@ -7,7 +7,7 @@
    [nodely.data :as data]
    [nodely.engine.core :as core]
    [nodely.fixtures :as fixtures]
-   [nodely.syntax :as syntax :refer [>cond >if >leaf]]
+   [nodely.syntax :as syntax :refer [>cond >if >leaf >sequence]]
    [schema.test]))
 
 (use-fixtures :once schema.test/validate-schemas)
@@ -68,6 +68,10 @@
 
 (def env-with-sequence {:x (data/value [1 2 3])
                         :y (data/sequence :x inc)})
+
+(def env-with-closure-sequence {:x (data/value [1 2 3])
+                                :z (data/value 2)
+                                :y (>sequence (fn [e] (* e ?z)) ?x)})
 
 (def branch-with-sequence {:x (data/value [1 2 3])
                            :y (data/value [4 5 6])
@@ -165,6 +169,11 @@
     (is (= {:x (data/value [1 2 3])
             :y (data/value [2 3 4])}
            (core/resolve :y env-with-sequence))))
+  (testing "resolve closure sequence"
+    (is (= {:x (data/value [1 2 3])
+            :z (data/value 2)
+            :y (data/value [2 4 6])}
+           (core/resolve :y env-with-closure-sequence))))
   (testing "resolve with nested branches"
     (is (= {:x (data/value 1)
             :y (data/value 2)

--- a/test/nodely/engine/manifold_test.clj
+++ b/test/nodely/engine/manifold_test.clj
@@ -27,6 +27,11 @@
 (def env-with-sequence {:a (>leaf [1 2 3])
                         :b (syntax/>sequence inc ?a)})
 
+(def env-with-sequence-with-closure
+  {:a (syntax/>value [1 2 3])
+   :c (syntax/>value 2)
+   :b (syntax/>sequence #(* % ?c) ?a)})
+
 (def env-with-sequence+delay {:a (>leaf [1 2 3])
                               :b (syntax/>sequence
                                   #(do (Thread/sleep 1000) (inc %))
@@ -54,7 +59,9 @@
       (is (match? (matchers/within-delta 8000000 2000000000)
                   (- nanosec-sync nanosec-async)))))
   (testing "Actually computes the correct answers"
-    (is (= [2 3 4] (manifold/eval-key env-with-sequence+delay :b)))))
+    (is (= [2 3 4] (manifold/eval-key env-with-sequence+delay :b))))
+  (testing "Supports closure of nodes in the iterated fn"
+    (is (= [2 4 6] (manifold/eval-key env-with-sequence-with-closure :b)))))
 
 (deftest eval-test
   (testing "eval node async"

--- a/test/nodely/syntax_test.clj
+++ b/test/nodely/syntax_test.clj
@@ -164,7 +164,8 @@
                       :fn     fn?}
           :b #::data {:type  :sequence
                       :input :a
-                      :fn fn?}}
+                      :process-node #::data {:type :value
+                                             :value fn?}}}
          {:a (>leaf [1 2 3])
           :b (>sequence inc ?a)}))))
 

--- a/test/nodely/syntax_test.clj
+++ b/test/nodely/syntax_test.clj
@@ -164,7 +164,7 @@
                       :fn     fn?}
           :b #::data {:type  :sequence
                       :input :a
-                      :fn-fn fn?}}
+                      :fn fn?}}
          {:a (>leaf [1 2 3])
           :b (>sequence inc ?a)}))))
 

--- a/test/nodely/syntax_test.clj
+++ b/test/nodely/syntax_test.clj
@@ -164,7 +164,7 @@
                       :fn     fn?}
           :b #::data {:type  :sequence
                       :input :a
-                      :fn    fn?}}
+                      :fn-fn fn?}}
          {:a (>leaf [1 2 3])
           :b (>sequence inc ?a)}))))
 


### PR DESCRIPTION
Allows closing over any named node in the mapped fn for sequence type nodes.

- Change the definition of the fn for a sequence from being a `ifn?` value at the `:nodely.data/fn` key to being a node embedded at the `:nodely.data/process-node` key of the sequence node.
- Obtaining the fn means eval the process-node and then apply the resulting fn from evaling.
- Tests in all engines asserting support for closing over nodes in sequence fns.