### PR TITLE
Provide helpful error message when an invalid engine is specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+- Improve ergonomics when an unknown engine is specified
+- Mark virtual future applicative engine as `eval-key-channel` true.
+
 ## 1.18.0 / 2024-06-20
 - Add virtual-future based applicative engine (for java21+)
 

--- a/src/nodely/api/v0.clj
+++ b/src/nodely/api/v0.clj
@@ -61,13 +61,17 @@
                      :applicative.virtual-future {::ns               (find-ns 'nodely.engine.applicative)
                                                   ::opts-fn          #(assoc % ::applicative/context
                                                                              (var-get (resolve 'nodely.engine.applicative.virtual-future/context)))
-                                                  ::eval-key-channel false})
+                                                  ::eval-key-channel true})
      (catch Exception e e))
 ;; End Virtual Threads
 
 (defn- engine-fn
   [engine-name use]
-  (ns-resolve (::ns (engine-data engine-name)) use))
+  (if-let [engine-data (engine-data engine-name)]
+    (ns-resolve (::ns engine-data) use)
+    (throw (ex-info "Unsupported engine specified, please specify a supported engine."
+                    {:specified-engine-name engine-name
+                     :supported-engine-names (set (keys engine-data))}))))
 
 (def engine-fn (memoize engine-fn))
 

--- a/test/nodely/api_test.clj
+++ b/test/nodely/api_test.clj
@@ -95,3 +95,46 @@
 (t/deftest api-test
   (for [engine (keys api/engine-data)]
     (engine-test-suite engine)))
+
+(t/deftest incorrect-engine-id
+  (t/testing "we communicate how the client has specified an invalid input and what would be valid inputs"
+    (t/testing "eval"
+      (t/matching #"Unsupported engine specified, please specify a supported engine."
+                  (try (api/eval env :z {::api/engine :core.async.doesnt-exist})
+                       (catch clojure.lang.ExceptionInfo e (ex-message e))))
+      (t/matching {:specified-engine-name  :core.async.doesnt-exist
+                   :supported-engine-names set?}
+                  (try (api/eval env :z {::api/engine :core.async.doesnt-exist})
+                       (catch clojure.lang.ExceptionInfo e (ex-data e)))))
+    (t/testing "eval-key"
+      (t/matching #"Unsupported engine specified, please specify a supported engine."
+                  (try (api/eval-key env :z {::api/engine :core.async.doesnt-exist})
+                       (catch clojure.lang.ExceptionInfo e (ex-message e))))
+      (t/matching {:specified-engine-name  :core.async.doesnt-exist
+                   :supported-engine-names set?}
+                  (try (api/eval-key env :z {::api/engine :core.async.doesnt-exist})
+                       (catch clojure.lang.ExceptionInfo e (ex-data e)))))
+    (t/testing "eval-key-channel"
+      (t/matching #"Unsupported engine specified, please specify a supported engine."
+                  (try (api/eval-key-channel env :z {::api/engine :core.async.doesnt-exist})
+                       (catch clojure.lang.ExceptionInfo e (ex-message e))))
+      (t/matching {:specified-engine-name  :core.async.doesnt-exist
+                   :supported-engine-names set?}
+                  (try (api/eval-key-channel env :z {::api/engine :core.async.doesnt-exist})
+                       (catch clojure.lang.ExceptionInfo e (ex-data e)))))
+    (t/testing "eval-node"
+      (t/matching #"Unsupported engine specified, please specify a supported engine."
+                  (try (api/eval-node env (>leaf (inc ?z)) {::api/engine :core.async.doesnt-exist})
+                       (catch clojure.lang.ExceptionInfo e (ex-message e))))
+      (t/matching {:specified-engine-name  :core.async.doesnt-exist
+                   :supported-engine-names set?}
+                  (try (api/eval-node env (>leaf (inc ?z)) {::api/engine :core.async.doesnt-exist})
+                       (catch clojure.lang.ExceptionInfo e (ex-data e)))))
+    (t/testing "eval-node-channel"
+      (t/matching #"Unsupported engine specified, please specify a supported engine."
+                  (try (api/eval-node-channel env (>leaf (inc ?z)) {::api/engine :core.async.doesnt-exist})
+                       (catch clojure.lang.ExceptionInfo e (ex-message e))))
+      (t/matching {:specified-engine-name  :core.async.doesnt-exist
+                   :supported-engine-names set?}
+                  (try (api/eval-node-channel env (>leaf (inc ?z)) {::api/engine :core.async.doesnt-exist})
+                       (catch clojure.lang.ExceptionInfo e (ex-data e)))))))


### PR DESCRIPTION
- Describe the problematic engine name as well as the set of supported engine names.
- Test across all entrypoints where engines are specified in api/v0
- w/ Sophia, Ugo and Joao