### PR TITLE
[FIX] Adapting inference context operation to accept nil cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.19.1 / 2024-08-28
+- Fix Contextual protocol to accept nil context cases
+
 ## 1.19.0 / 2024-08-15
 - Remove applicative engine dependency from funcool/cats
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject dev.nu/nodely "1.19.0"
+(defproject dev.nu/nodely "1.19.1"
   :description "Decoupling data fetching from data dependency declaration"
   :url "https://github.com/nubank/nodely"
   :license {:name "MIT"}

--- a/src/nodely/engine/applicative/core.clj
+++ b/src/nodely/engine/applicative/core.clj
@@ -22,17 +22,20 @@
   java.lang.Object
   (-get-context [_] nil))
 
+(extend-protocol p/Contextual
+  nil
+  (-get-context [_] nil))
+
 (defn infer
   "Given an optional value infer its context. If context is already set, it
   is returned as is without any inference operation."
   {:no-doc true}
   [v]
-  (or
-   (when (nil? v) v)
-   (p/-get-context v)
-   (throw-illegal-argument
-    (str "No context is set and it can not be automatically "
-         "resolved from provided value"))))
+  (if-let [context (p/-get-context v)]
+    context
+    (throw-illegal-argument
+     (str "No context is set and it can not be automatically "
+          "resolved from provided value"))))
 
 ;; END CONTEXT STUFF
 

--- a/src/nodely/engine/applicative/core.clj
+++ b/src/nodely/engine/applicative/core.clj
@@ -27,11 +27,12 @@
   is returned as is without any inference operation."
   {:no-doc true}
   [v]
-  (if-let [context (p/-get-context v)]
-    context
-    (throw-illegal-argument
-     (str "No context is set and it can not be automatically "
-          "resolved from provided value"))))
+  (or
+   (when (nil? v) v)
+   (p/-get-context v)
+   (throw-illegal-argument
+    (str "No context is set and it can not be automatically "
+         "resolved from provided value"))))
 
 ;; END CONTEXT STUFF
 

--- a/test/nodely/fixtures.clj
+++ b/test/nodely/fixtures.clj
@@ -22,8 +22,10 @@
 
 (defn leaf-gen
   [env]
-  (gen/let [inputs (subset (keys env))]
-    (data/leaf inputs identity)))
+  (gen/let [inputs (subset (keys env))
+            f (gen/frequency [[1 (gen/return (constantly nil))]
+                              [9 (gen/return identity)]])]
+    (data/leaf inputs f)))
 
 (defn scalar-gen
   [env]


### PR DESCRIPTION
After [removing dependency from the cats' library](https://github.com/nubank/nodely/pull/36), we need to fix the inference operation from the `Contextual` protocol to accept `nil` cases.

Currently, we're facing `IllegalArgumentExceptions` after using the new `Contextual` protocol.