### PR TITLE
Prune dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.0.0 / 2024-10-17
+- Breaking change: removed transitive dependencies
+-- The following dependencies are no longer transitively provided,
+   but, if otherwise made available on the classpath will continue to be
+   supported: org.clojure/core.async, funcool/promesa, manifold
+-- No code changes are required, but, if using an engine that is
+   powered by one of these libraries, then clients must include
+   these libraries on their classpath explicitly, or, transitively
+   include them through some other library.
+
 ## 1.19.0 / 2024-08-15
 - Remove applicative engine dependency from funcool/cats
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject dev.nu/nodely "1.19.0"
+(defproject dev.nu/nodely "2.0.0"
   :description "Decoupling data fetching from data dependency declaration"
   :url "https://github.com/nubank/nodely"
   :license {:name "MIT"}

--- a/project.clj
+++ b/project.clj
@@ -8,9 +8,9 @@
 
   :dependencies [[org.clojure/clojure "1.10.3"]
                  [aysylu/loom "1.0.2"]
-                 [org.clojure/core.async "1.5.648"]
-                 [funcool/promesa "10.0.594"]
-                 [manifold "0.1.9-alpha5"]
+                 [org.clojure/core.async "1.5.648" :scope "provided"]
+                 [funcool/promesa "10.0.594" :scope "provided"]
+                 [manifold "0.1.9-alpha5" :scope "provided"]
                  [prismatic/schema "1.1.12"]]
 
   :exclusions [log4j]

--- a/src/nodely/api/v0.clj
+++ b/src/nodely/api/v0.clj
@@ -3,12 +3,9 @@
   (:require
    [nodely.data]
    [nodely.engine.applicative :as applicative]
-   [nodely.engine.applicative.core-async :as applicative.core-async]
-   [nodely.engine.applicative.promesa :as applicative.promesa]
+
+   [nodely.engine.applicative.promesa :as applicative.promesa] ;; promesa
    [nodely.engine.core :as engine-core]
-   [nodely.engine.core-async.core]
-   [nodely.engine.core-async.iterative-scheduling]
-   [nodely.engine.core-async.lazy-scheduling]
    [nodely.engine.lazy]
    [nodely.engine.manifold]
    [nodely.syntax]
@@ -33,45 +30,79 @@
 (import-fn nodely.data/merge-values merge-values)
 (import-fn nodely.data/get-value get-value)
 
-(def engine-data
-  {:core-async.lazy-scheduling      {::ns (find-ns 'nodely.engine.core-async.lazy-scheduling)
-                                     ::opts-fn identity
-                                     ::eval-key-channel true}
-   :core-async.iterative-scheduling {::ns (find-ns 'nodely.engine.core-async.iterative-scheduling)
-                                     ::opts-fn identity}
-   :async.manifold                  {::ns (find-ns 'nodely.engine.manifold)
-                                     ::opts-fn (constantly nil)}
-   :applicative.promesa             {::ns (find-ns 'nodely.engine.applicative)
-                                     ::opts-fn #(assoc % ::applicative/context applicative.promesa/context)}
-   :applicative.core-async          {::ns (find-ns 'nodely.engine.applicative)
-                                     ::opts-fn #(assoc % ::applicative/context applicative.core-async/context)
-                                     ::eval-key-channel true}
-   :sync.lazy                       {::ns (find-ns 'nodely.engine.lazy)
-                                     ::opts-fn (constantly nil)
-                                     ::eval-key-channel true}})
 
-;; Java 21 Virtual Threads Support
-(try (import java.util.concurrent.ThreadPerTaskExecutor)
-     (require '[nodely.engine.virtual-workers])
-     (require '[nodely.engine.applicative.virtual-future :as applicative.virtual-future])
-     (alter-var-root #'engine-data assoc
-                     :async.virtual-futures {::ns               (find-ns 'nodely.engine.virtual-workers)
-                                             ::opts-fn          (constantly nil)
-                                             ::eval-key-channel true}
-                     :applicative.virtual-future {::ns               (find-ns 'nodely.engine.applicative)
-                                                  ::opts-fn          #(assoc % ::applicative/context
-                                                                             (var-get (resolve 'nodely.engine.applicative.virtual-future/context)))
-                                                  ::eval-key-channel true})
-     (catch Exception e e))
-;; End Virtual Threads
+(def virtual-future-failure
+  (delay
+    (try (import java.util.concurrent.ThreadPerTaskExecutor)
+         (require '[nodely.engine.virtual-workers]
+                  '[nodely.engine.applicative.virtual-future :as applicative.virtual-future])
+         (catch Exception e
+           {:msg              "Classloader could not locate `java.util.concurrent.ThreadPerTaskExecutor`, virtual futures require JDK 21 or higher."
+            ::error           :missing-class
+            ::requested-class "java.util.concurrent.ThreadPerTaskExecutor"
+            :cause            e}))))
+
+(def core-async-failure
+  (delay
+    (try (require '[nodely.engine.applicative.core-async :as applicative.core-async]
+                  '[nodely.engine.core-async.core]
+                  '[nodely.engine.core-async.iterative-scheduling]
+                  '[nodely.engine.core-async.lazy-scheduling])
+         (catch Exception e
+           {:msg                   "Could not locate core-async on classpath."
+            ::error                :missing-ns
+            ::requested-namespaces '[nodely.engine.core-async.core
+                                     nodely.engine.core-async.iterative-scheduling
+                                     nodely.engine.core-async.lazy-scheduling]
+            :cause                 e}))))
+
+(defn manifold-failure)
+
+(defn promesa-failure)
+
+(def engine-data
+  {:core-async.lazy-scheduling      {::ns-name          'nodely.engine.core-async.lazy-scheduling
+                                     ::opts-fn          identity
+                                     ::enable-deref     core-async-failure
+                                     ::eval-key-channel true}
+   :core-async.iterative-scheduling {::ns-name          'nodely.engine.core-async.iterative-scheduling
+                                     ::opts-fn          identity
+                                     ::enable-deref     core-async-failure}
+   :async.manifold                  {::ns-name          'nodely.engine.manifold
+                                     ::opts-fn          (constantly nil)
+                                     ::enable-deref     (atom nil)}
+   :applicative.promesa             {::ns-name          'nodely.engine.applicative
+                                     ::opts-fn          #(assoc % ::applicative/context applicative.promesa/context)
+                                     ::enable-deref     (atom nil)}
+   :applicative.core-async          {::ns-name          'nodely.engine.applicative
+                                     ::opts-fn          #(assoc % ::applicative/context applicative.core-async/context)
+                                     ::eval-key-channel true
+                                     ::enable-deref     core-async-failure}
+   :sync.lazy                       {::ns-name          'nodely.engine.lazy
+                                     ::opts-fn          (constantly nil)
+                                     ::eval-key-channel true
+                                     ::enable-deref     (delay nil)}
+   :async.virtual-futures           {::ns-name          'nodely.engine.virtual-workers
+                                     ::opts-fn          (constantly nil)
+                                     ::eval-key-channel true
+                                     ::enable-deref     virtual-future-failure}
+   :applicative.virtual-future      {::ns-name          'nodely.engine.applicative
+                                     ::opts-fn          #(assoc % ::applicative/context
+                                                                (var-get (resolve 'nodely.engine.applicative.virtual-future/context)))
+                                     ::eval-key-channel true
+                                     ::enable-deref     virtual-future-failure}
+   })
 
 (defn- engine-fn
   [engine-name use]
-  (if-let [engine-data (engine-data engine-name)]
-    (ns-resolve (::ns engine-data) use)
-    (throw (ex-info "Unsupported engine specified, please specify a supported engine."
-                    {:specified-engine-name engine-name
-                     :supported-engine-names (set (keys engine-data))}))))
+  (let [engine-data (engine-data engine-name)]
+    (if-let [{:keys [msg cause] :as enable-failure} @(::enable-deref engine-data)]
+      (throw (ex-info msg
+                      (-> enable-failure
+                          (dissoc :msg :cause)
+                          (assoc ::specified-engine-name engine-name))
+                      cause))
+      (ns-resolve (find-ns (::ns-name engine-data)) use))))
 
 (def engine-fn (memoize engine-fn))
 

--- a/src/nodely/api/v0.clj
+++ b/src/nodely/api/v0.clj
@@ -28,47 +28,47 @@
 
 (def virtual-future-failure
   (delay
-    (try (import java.util.concurrent.ThreadPerTaskExecutor)
-         (require 'nodely.engine.virtual-workers
-                  'nodely.engine.applicative.virtual-future)
-         (catch Exception e
-           {:msg              "Classloader could not locate `java.util.concurrent.ThreadPerTaskExecutor`, virtual futures require JDK 21 or higher."
-            ::error           :missing-class
-            ::requested-class "java.util.concurrent.ThreadPerTaskExecutor"
-            :cause            e}))))
+   (try (import java.util.concurrent.ThreadPerTaskExecutor)
+        (require 'nodely.engine.virtual-workers
+                 'nodely.engine.applicative.virtual-future)
+        (catch Exception e
+          {:msg              "Classloader could not locate `java.util.concurrent.ThreadPerTaskExecutor`, virtual futures require JDK 21 or higher."
+           ::error           :missing-class
+           ::requested-class "java.util.concurrent.ThreadPerTaskExecutor"
+           :cause            e}))))
 
 (def core-async-failure
   (delay
-    (try (require 'nodely.engine.applicative.core-async
-                  'nodely.engine.core-async.core
-                  'nodely.engine.core-async.iterative-scheduling
-                  'nodely.engine.core-async.lazy-scheduling)
-         (catch Exception e
-           {:msg                   "Could not locate core-async on classpath."
-            ::error                :missing-ns
-            ::requested-namespaces '[nodely.engine.applicative.core-async
-                                     nodely.engine.core-async.core
-                                     nodely.engine.core-async.iterative-scheduling
-                                     nodely.engine.core-async.lazy-scheduling]
-            :cause                 e}))))
+   (try (require 'nodely.engine.applicative.core-async
+                 'nodely.engine.core-async.core
+                 'nodely.engine.core-async.iterative-scheduling
+                 'nodely.engine.core-async.lazy-scheduling)
+        (catch Exception e
+          {:msg                   "Could not locate core-async on classpath."
+           ::error                :missing-ns
+           ::requested-namespaces '[nodely.engine.applicative.core-async
+                                    nodely.engine.core-async.core
+                                    nodely.engine.core-async.iterative-scheduling
+                                    nodely.engine.core-async.lazy-scheduling]
+           :cause                 e}))))
 
 (def manifold-failure
   (delay
-    (try (require 'nodely.engine.manifold)
-         (catch Exception e
-           {:msg                   "Could not locate manifold on classpath."
-            ::error                :missing-ns
-            ::requested-namespaces '[nodely.engine.manifold]
-            :cause                 e}))))
+   (try (require 'nodely.engine.manifold)
+        (catch Exception e
+          {:msg                   "Could not locate manifold on classpath."
+           ::error                :missing-ns
+           ::requested-namespaces '[nodely.engine.manifold]
+           :cause                 e}))))
 
 (def promesa-failure
   (delay
-    (try (require 'nodely.engine.applicative.promesa)
-         (catch Exception e
-           {:msg                   "Could not locate promesa on classpath."
-            ::error                :missing-ns
-            ::requested-namespaces '[nodely.engine.applicative.promesa]
-            :cause                 e}))))
+   (try (require 'nodely.engine.applicative.promesa)
+        (catch Exception e
+          {:msg                   "Could not locate promesa on classpath."
+           ::error                :missing-ns
+           ::requested-namespaces '[nodely.engine.applicative.promesa]
+           :cause                 e}))))
 
 (def engine-data
   {:core-async.lazy-scheduling      {::ns-name          'nodely.engine.core-async.lazy-scheduling
@@ -111,8 +111,8 @@
     (if-let [{:keys [msg cause] :as enable-failure} @core-async-failure]
       (throw (ex-info msg (dissoc enable-failure :msg :cause) cause))
       (list `nodely.engine.core-async.core/channel-leaf
-          (mapv #'syntax/question-mark->keyword symbols-to-be-replaced)
-          fn-expr))))
+            (mapv #'syntax/question-mark->keyword symbols-to-be-replaced)
+            fn-expr))))
 
 (defn- engine-fn
   [engine-name use]

--- a/src/nodely/api/v0.clj
+++ b/src/nodely/api/v0.clj
@@ -29,8 +29,8 @@
 (def virtual-future-failure
   (delay
     (try (import java.util.concurrent.ThreadPerTaskExecutor)
-         (require '[nodely.engine.virtual-workers]
-                  '[nodely.engine.applicative.virtual-future :as applicative.virtual-future])
+         (require 'nodely.engine.virtual-workers
+                  'nodely.engine.applicative.virtual-future)
          (catch Exception e
            {:msg              "Classloader could not locate `java.util.concurrent.ThreadPerTaskExecutor`, virtual futures require JDK 21 or higher."
             ::error           :missing-class
@@ -39,21 +39,22 @@
 
 (def core-async-failure
   (delay
-    (try (do (require '[nodely.engine.applicative.core-async :as applicative.core-async]
-                      '[nodely.engine.core-async.core]
-                      '[nodely.engine.core-async.iterative-scheduling]
-                      '[nodely.engine.core-async.lazy-scheduling]))
+    (try (require 'nodely.engine.applicative.core-async
+                  'nodely.engine.core-async.core
+                  'nodely.engine.core-async.iterative-scheduling
+                  'nodely.engine.core-async.lazy-scheduling)
          (catch Exception e
            {:msg                   "Could not locate core-async on classpath."
             ::error                :missing-ns
-            ::requested-namespaces '[nodely.engine.core-async.core
+            ::requested-namespaces '[nodely.engine.applicative.core-async
+                                     nodely.engine.core-async.core
                                      nodely.engine.core-async.iterative-scheduling
                                      nodely.engine.core-async.lazy-scheduling]
             :cause                 e}))))
 
 (def manifold-failure
   (delay
-    (try (require '[nodely.engine.manifold])
+    (try (require 'nodely.engine.manifold)
          (catch Exception e
            {:msg                   "Could not locate manifold on classpath."
             ::error                :missing-ns
@@ -62,11 +63,11 @@
 
 (def promesa-failure
   (delay
-    (try (require '[nodely.engine.applicative.promesa :as applicative.promesa])
+    (try (require 'nodely.engine.applicative.promesa)
          (catch Exception e
            {:msg                   "Could not locate promesa on classpath."
             ::error                :missing-ns
-            ::requested-namespaces '[nodely.engine.applicative.promesa :as applicative.promesa]
+            ::requested-namespaces '[nodely.engine.applicative.promesa]
             :cause                 e}))))
 
 (def engine-data

--- a/test/nodely/api_test.clj
+++ b/test/nodely/api_test.clj
@@ -195,10 +195,14 @@
       (t/matching 7 (api/eval-key env+channel-leaf :c {::api/engine engine-key})))))
 
 (t/deftest api-test
-  (for [engine (set/difference (set (keys api/engine-data))
-                               #{:core-async.iterative-scheduling
-                                 :async.virtual-futures})]
-    (engine-test-suite engine)))
+  (let [remove-keys (conj #{:core-async.iterative-scheduling
+                            :async.virtual-futures}
+                          (when  (try (import java.util.concurrent.ThreadPerTaskExecutor)
+                                      (catch Throwable t t))
+                            :applicative.virtual-future))]
+    (for [engine (set/difference (set (keys api/engine-data))
+                                 remove-keys)]
+      (engine-test-suite engine))))
 
 (t/deftest incorrect-engine-id
   (t/testing "we communicate how the client has specified an invalid input and what would be valid inputs"

--- a/test/nodely/api_test.clj
+++ b/test/nodely/api_test.clj
@@ -64,54 +64,83 @@
   (when (realized? (deref (resolve sym)))
     (require :reload '[nodely.api.v0])))
 
-(defmacro with-fresh-delay
-  [delay & body]
-  `(do (ensure-unrealized-delay (quote ~delay))
-       (let [res# ~@body]
-         (require :reload 'nodely.api.v0)
-         res#)))
+(defn- testing-require-delay-call
+  [ns-sym delay message cause call-fn]
+  (do (ensure-unrealized-delay delay)
+      (let [orig-require require
+            bomb         (fn [& args]
+                           (if ((set args) ns-sym)
+                             (throw (ex-info message
+                                             {:cause cause}))
+                             (apply orig-require args)))
+            res          (with-redefs [require bomb]
+                            (call-fn))]
+        (require :reload 'nodely.api.v0)
+        res)))
+
+(defmacro testing-require-delay
+  [ns-sym delay message cause & body]
+  `(testing-require-delay-call ~ns-sym (quote ~delay)
+                               ~message ~cause (^{:once true} fn* [] ~@body)))
 
 (t/deftest engine-without-support
-  (t/testing "attempting to use virtual futures without virtual futures in the JVM"
-    (with-fresh-delay nodely.api.v0/virtual-future-failure
-      (t/matching
-       #"Classloader could not locate `java.util.concurrent.ThreadPerTaskExecutor`"
-       (with-redefs [require (fn [& args]
-                               (throw (ex-info "Kaboom! We're not on JVM 21 for pretend"
-                                               {:cause :test-virtual-future-failure})))]
-         (try (api/eval-key-channel env :z {::api/engine :applicative.virtual-future})
-              (catch Throwable t
-                (ex-message t)))))))
-  (t/testing "attempting to use core.async without core.async on the classpath"
-    (with-fresh-delay nodely.api.v0/core-async-failure
-      (t/matching
-       #"Could not locate core-async on classpath"
-       (with-redefs [require (fn [& args]
-                               (throw (ex-info "Kaboom! We don't have core.async for pretend"
-                                               {:cause :test-core-async-failure})))]
-         (try (api/eval-key-channel env :z {::api/engine :core-async.lazy-scheduling})
-              (catch Throwable t
-                (ex-message t)))))))
-  (t/testing "attempting to use manifold without manifold on the classpath"
-    (with-fresh-delay nodely.api.v0/manifold-failure
-      (t/matching
-       #"Could not locate manifold on classpath"
-       (with-redefs [require (fn [& args]
-                               (throw (ex-info "Kaboom! We're don't have manifold for pretend"
-                                               {:cause :test-manifold-failure})))]
-         (try (api/eval-key-channel env :z {::api/engine :async.manifold})
-              (catch Throwable t
-                (ex-message t)))))))
-  (t/testing "attempting to use promesa without promesa on the classpath"
-    (with-fresh-delay nodely.api.v0/promesa-failure
-      (t/matching
-       #"Could not locate promesa on classpath"
-       (with-redefs [require (fn [& args]
-                               (throw (ex-info "Kaboom! We're don't have promesa for pretend"
-                                               {:cause :test-promesa-failure})))]
-         (try (api/eval-key-channel env :z {::api/engine :applicative.promesa})
-              (catch Throwable t
-                (ex-message t))))))))
+  (t/testing "engines blowing up"
+    (testing-require-delay
+        'nodely.engine.virtual-workers nodely.api.v0/virtual-future-failure
+        "Kaboom! We're not on JVM 21 for pretend" :test-virtual-future-failure
+        (t/testing "without virtual futures in the JVM"
+          (t/testing "attempting to use virtual futures"
+            (t/matching
+             #"Classloader could not locate `java.util.concurrent.ThreadPerTaskExecutor`"
+             (try (api/eval-key-channel env :z {::api/engine :applicative.virtual-future})
+                  (catch Throwable t
+                    (ex-message t)))))
+          (t/testing "attempting to use core.async"
+            (t/matching
+             5
+             (async/<!! (api/eval-key-channel env :z {::api/engine :core-async.lazy-scheduling}))))))
+    (testing-require-delay
+        'nodely.engine.core-async.core nodely.api.v0/core-async-failure
+        "Kaboom! We don't have core.async for pretend" :test-core-async-failure
+      (t/testing "without core.async on the classpath"
+        (t/testing "attempting to use core.async"
+          (t/matching
+           #"Could not locate core-async on classpath"
+           (try (api/eval-key-channel env :z {::api/engine :core-async.lazy-scheduling})
+                (catch Throwable t
+                  (ex-message t)))))
+        (t/testing "attempting to use manifold"
+          (t/matching
+           5
+           (api/eval-key env :z {::api/engine :async.manifold})))))
+    (testing-require-delay
+        'nodely.engine.manifold nodely.api.v0/manifold-failure
+        "Kaboom! We don't have manifold for pretend" :test-manifold-failure
+      (t/testing "without manifold on the classpath"
+        (t/testing "attempting to use manifold"
+          (t/matching
+           #"Could not locate manifold on classpath"
+           (try (api/eval-key-channel env :z {::api/engine :async.manifold})
+                (catch Throwable t
+                  (ex-message t)))))
+        (t/testing "attempting to use core.async"
+          (t/matching
+           5
+           (async/<!! (api/eval-key-channel env :z {::api/engine :core-async.lazy-scheduling}))))))
+    (testing-require-delay
+        'nodely.engine.applicative.promesa nodely.api.v0/promesa-failure
+        "Kaboom! We don't have promesa for pretend" :test-promesa-failure
+      (t/testing "attempting to use promesa without promesa on the classpath"
+        (t/testing "attempting to use promesa"
+          (t/matching
+           #"Could not locate promesa on classpath"
+           (try (api/eval-key-channel env :z {::api/engine :applicative.promesa})
+                (catch Throwable t
+                  (ex-message t)))))
+        (t/testing "attempting to use core.async"
+          (t/matching
+           5
+           (async/<!! (api/eval-key-channel env :z {::api/engine :core-async.lazy-scheduling}))))))))
 
 (defn engine-test-suite
   [engine-key]

--- a/test/nodely/api_test.clj
+++ b/test/nodely/api_test.clj
@@ -80,13 +80,13 @@
 
 (defmacro testing-require-delay
   [ns-sym delay message cause & body]
-  `(testing-require-delay-call ~ns-sym (quote ~delay)
+  `(testing-require-delay-call (quote ~ns-sym) (quote ~delay)
                                ~message ~cause (^{:once true} fn* [] ~@body)))
 
 (t/deftest engine-without-support
   (t/testing "engines blowing up"
     (testing-require-delay
-        'nodely.engine.virtual-workers nodely.api.v0/virtual-future-failure
+        nodely.engine.virtual-workers nodely.api.v0/virtual-future-failure
         "Kaboom! We're not on JVM 21 for pretend" :test-virtual-future-failure
         (t/testing "without virtual futures in the JVM"
           (t/testing "attempting to use virtual futures"
@@ -100,7 +100,7 @@
              5
              (async/<!! (api/eval-key-channel env :z {::api/engine :core-async.lazy-scheduling}))))))
     (testing-require-delay
-        'nodely.engine.core-async.core nodely.api.v0/core-async-failure
+        nodely.engine.core-async.core nodely.api.v0/core-async-failure
         "Kaboom! We don't have core.async for pretend" :test-core-async-failure
       (t/testing "without core.async on the classpath"
         (t/testing "attempting to use core.async"
@@ -114,7 +114,7 @@
            5
            (api/eval-key env :z {::api/engine :async.manifold})))))
     (testing-require-delay
-        'nodely.engine.manifold nodely.api.v0/manifold-failure
+        nodely.engine.manifold nodely.api.v0/manifold-failure
         "Kaboom! We don't have manifold for pretend" :test-manifold-failure
       (t/testing "without manifold on the classpath"
         (t/testing "attempting to use manifold"
@@ -128,7 +128,7 @@
            5
            (async/<!! (api/eval-key-channel env :z {::api/engine :core-async.lazy-scheduling}))))))
     (testing-require-delay
-        'nodely.engine.applicative.promesa nodely.api.v0/promesa-failure
+        nodely.engine.applicative.promesa nodely.api.v0/promesa-failure
         "Kaboom! We don't have promesa for pretend" :test-promesa-failure
       (t/testing "attempting to use promesa without promesa on the classpath"
         (t/testing "attempting to use promesa"

--- a/test/nodely/api_test.clj
+++ b/test/nodely/api_test.clj
@@ -41,6 +41,11 @@
                            :i (blocking (>leaf (do (Thread/sleep 1000) :i)))
                            :z (>leaf (into #{} [?a ?b ?c ?d ?e ?f ?g ?h ?i]))})
 
+(def env+channel-leaf {:a (>value 1)
+                       :b (api/>channel-leaf
+                           (async/go (+ ?a 5)))
+                       :c (>leaf (+ ?a ?b))})
+
 (def parallel-engines
   #{:core-async.lazy-scheduling
     :core-async.iterative-scheduling
@@ -102,7 +107,10 @@
     (t/testing "handling nested exceptions"
       (t/matching #"Oops!"
                   (try (api/eval-key exceptions-all-the-way-down :d {::api/engine engine-key})
-                       (catch clojure.lang.ExceptionInfo e (ex-message e)))))))
+                       (catch clojure.lang.ExceptionInfo e (ex-message e)))))
+
+    (t/testing "env with >channel-leaf"
+      (t/matching 7 (api/eval-key env+channel-leaf :c {::api/engine engine-key})))))
 
 (t/deftest api-test
   (for [engine (set/difference (set (keys api/engine-data))

--- a/test/nodely/api_test.clj
+++ b/test/nodely/api_test.clj
@@ -74,7 +74,7 @@
                                              {:cause cause}))
                              (apply orig-require args)))
             res          (with-redefs [require bomb]
-                            (call-fn))]
+                           (call-fn))]
         (require :reload 'nodely.api.v0)
         res)))
 
@@ -86,61 +86,61 @@
 (t/deftest engine-without-support
   (t/testing "engines blowing up"
     (testing-require-delay
-        nodely.engine.virtual-workers nodely.api.v0/virtual-future-failure
-        "Kaboom! We're not on JVM 21 for pretend" :test-virtual-future-failure
-        (t/testing "without virtual futures in the JVM"
-          (t/testing "attempting to use virtual futures"
-            (t/matching
-             #"Classloader could not locate `java.util.concurrent.ThreadPerTaskExecutor`"
-             (try (api/eval-key-channel env :z {::api/engine :applicative.virtual-future})
-                  (catch Throwable t
-                    (ex-message t)))))
-          (t/testing "attempting to use core.async"
-            (t/matching
-             5
-             (async/<!! (api/eval-key-channel env :z {::api/engine :core-async.lazy-scheduling}))))))
+     nodely.engine.virtual-workers nodely.api.v0/virtual-future-failure
+     "Kaboom! We're not on JVM 21 for pretend" :test-virtual-future-failure
+     (t/testing "without virtual futures in the JVM"
+       (t/testing "attempting to use virtual futures"
+         (t/matching
+          #"Classloader could not locate `java.util.concurrent.ThreadPerTaskExecutor`"
+          (try (api/eval-key-channel env :z {::api/engine :applicative.virtual-future})
+               (catch Throwable t
+                 (ex-message t)))))
+       (t/testing "attempting to use core.async"
+         (t/matching
+          5
+          (async/<!! (api/eval-key-channel env :z {::api/engine :core-async.lazy-scheduling}))))))
     (testing-require-delay
-        nodely.engine.core-async.core nodely.api.v0/core-async-failure
-        "Kaboom! We don't have core.async for pretend" :test-core-async-failure
-      (t/testing "without core.async on the classpath"
-        (t/testing "attempting to use core.async"
-          (t/matching
-           #"Could not locate core-async on classpath"
-           (try (api/eval-key-channel env :z {::api/engine :core-async.lazy-scheduling})
-                (catch Throwable t
-                  (ex-message t)))))
-        (t/testing "attempting to use manifold"
-          (t/matching
-           5
-           (api/eval-key env :z {::api/engine :async.manifold})))))
+     nodely.engine.core-async.core nodely.api.v0/core-async-failure
+     "Kaboom! We don't have core.async for pretend" :test-core-async-failure
+     (t/testing "without core.async on the classpath"
+       (t/testing "attempting to use core.async"
+         (t/matching
+          #"Could not locate core-async on classpath"
+          (try (api/eval-key-channel env :z {::api/engine :core-async.lazy-scheduling})
+               (catch Throwable t
+                 (ex-message t)))))
+       (t/testing "attempting to use manifold"
+         (t/matching
+          5
+          (api/eval-key env :z {::api/engine :async.manifold})))))
     (testing-require-delay
-        nodely.engine.manifold nodely.api.v0/manifold-failure
-        "Kaboom! We don't have manifold for pretend" :test-manifold-failure
-      (t/testing "without manifold on the classpath"
-        (t/testing "attempting to use manifold"
-          (t/matching
-           #"Could not locate manifold on classpath"
-           (try (api/eval-key-channel env :z {::api/engine :async.manifold})
-                (catch Throwable t
-                  (ex-message t)))))
-        (t/testing "attempting to use core.async"
-          (t/matching
-           5
-           (async/<!! (api/eval-key-channel env :z {::api/engine :core-async.lazy-scheduling}))))))
+     nodely.engine.manifold nodely.api.v0/manifold-failure
+     "Kaboom! We don't have manifold for pretend" :test-manifold-failure
+     (t/testing "without manifold on the classpath"
+       (t/testing "attempting to use manifold"
+         (t/matching
+          #"Could not locate manifold on classpath"
+          (try (api/eval-key-channel env :z {::api/engine :async.manifold})
+               (catch Throwable t
+                 (ex-message t)))))
+       (t/testing "attempting to use core.async"
+         (t/matching
+          5
+          (async/<!! (api/eval-key-channel env :z {::api/engine :core-async.lazy-scheduling}))))))
     (testing-require-delay
-        nodely.engine.applicative.promesa nodely.api.v0/promesa-failure
-        "Kaboom! We don't have promesa for pretend" :test-promesa-failure
-      (t/testing "attempting to use promesa without promesa on the classpath"
-        (t/testing "attempting to use promesa"
-          (t/matching
-           #"Could not locate promesa on classpath"
-           (try (api/eval-key-channel env :z {::api/engine :applicative.promesa})
-                (catch Throwable t
-                  (ex-message t)))))
-        (t/testing "attempting to use core.async"
-          (t/matching
-           5
-           (async/<!! (api/eval-key-channel env :z {::api/engine :core-async.lazy-scheduling}))))))))
+     nodely.engine.applicative.promesa nodely.api.v0/promesa-failure
+     "Kaboom! We don't have promesa for pretend" :test-promesa-failure
+     (t/testing "attempting to use promesa without promesa on the classpath"
+       (t/testing "attempting to use promesa"
+         (t/matching
+          #"Could not locate promesa on classpath"
+          (try (api/eval-key-channel env :z {::api/engine :applicative.promesa})
+               (catch Throwable t
+                 (ex-message t)))))
+       (t/testing "attempting to use core.async"
+         (t/matching
+          5
+          (async/<!! (api/eval-key-channel env :z {::api/engine :core-async.lazy-scheduling}))))))))
 
 (defn engine-test-suite
   [engine-key]


### PR DESCRIPTION
Make the additional dependencies (core-async, promesa, manifold etc.) have to be provided by the client (so that we don't import deps that are not needed)