### PR TITLE
Allow to include namespaced symbols in the implicit arg symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.1 / 2024-11-07
+- Allow implicit args for nodely syntax macros (e.g. >leaf) to include namespaces in the implicit arg symbols.
+
 ## 2.0.0 / 2024-10-17
 - Breaking change: removed transitive dependencies
 -- The following dependencies are no longer transitively provided,

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject dev.nu/nodely "2.0.0"
+(defproject dev.nu/nodely "2.0.1"
   :description "Decoupling data fetching from data dependency declaration"
   :url "https://github.com/nubank/nodely"
   :license {:name "MIT"}

--- a/src/nodely/syntax.clj
+++ b/src/nodely/syntax.clj
@@ -1,7 +1,7 @@
 (ns nodely.syntax
   (:require
-   [clojure.string :as string]
    [clojure.set :as set]
+   [clojure.string :as string]
    [clojure.walk :as walk]
    [nodely.data :as data]))
 

--- a/src/nodely/syntax.clj
+++ b/src/nodely/syntax.clj
@@ -7,18 +7,18 @@
   [expr]
   (set (filter (complement seqable?) (tree-seq seqable? seq expr))))
 
+(defn- question-mark->keyword
+  [s]
+  (-> (str s) (subs 1) keyword))
+
 (defn- fn-with-arg-map
   [args expr]
   (let [arg-map (->> args
                      (map (fn [s]
-                            [s (-> s name (subs 1) keyword)]))
+                            [s (question-mark->keyword s)]))
                      (into {}))]
     (list `fn [(or (not-empty arg-map) '_)]
           expr)))
-
-(defn- question-mark->keyword
-  [s]
-  (-> (name s) (subs 1) keyword))
 
 (defn- question-mark-symbols
   [expr]
@@ -49,7 +49,7 @@
   [expr]
   (let [symbols-to-be-replaced (question-mark-symbols expr)]
     (assert-not-shadowing! symbols-to-be-replaced)
-    (list `data/leaf (mapv (comp keyword #(subs % 1) name) symbols-to-be-replaced)
+    (list `data/leaf (mapv question-mark->keyword symbols-to-be-replaced)
           (fn-with-arg-map symbols-to-be-replaced expr))))
 
 (defn >and

--- a/test/nodely/syntax_test.clj
+++ b/test/nodely/syntax_test.clj
@@ -208,3 +208,13 @@
   (testing "Flags a node with the blocking tag"
     (is (match? #::data{:type :leaf :inputs #{:x :y} :fn ifn? :tags #{::data/blocking}}
                 (blocking (>leaf (+ ?x ?y)))))))
+
+(deftest namespaced-question-mark-symbols
+  (testing "Can make leafs with question mark namespaced symbols"
+    (is (match? #::data{:type :leaf :inputs #{:foo/bar :baz/quux} :fn ifn?}
+                (>leaf (+ ?foo/bar ?baz/quux))))
+    (is (match? #::data{:type :sequence
+                        :input :foo/bar
+                        :process-node #::data{:type :value
+                                              :value ifn?}}
+                (>sequence inc ?foo/bar)))))


### PR DESCRIPTION
## 2.0.1 / 2024-11-07

- Allow implicit args for nodely syntax macros (e.g. >leaf) to include namespaces in the implicit arg symbols.