### PR TITLE
Remove the default engine behavior in internal applicative eval functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.2 / 2024-11-14
+- Remove the default engine behavior in internal applicative eval functions
+
 ## 2.0.1 / 2024-11-07
 - Allow implicit args for nodely syntax macros (e.g. >leaf) to include namespaces in the implicit arg symbols.
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject dev.nu/nodely "2.0.1"
+(defproject dev.nu/nodely "2.0.2"
   :description "Decoupling data fetching from data dependency declaration"
   :url "https://github.com/nubank/nodely"
   :license {:name "MIT"}


### PR DESCRIPTION
## Context

Following a change https://github.com/nubank/nodely/pull/38 in how dependencies are provided, services importing Nodely (indirectly through `nodely-helpers`) began facing errors. This occurred because services were not explicitly providing `promesa` as a dependency, even if they were not using it. 

The issue stemmed from Nodely's applicative engine eval functions, which would default to using the promesa engine if no engine was specified. This resulted in `promesa` being included as a required dependency.

Since applicative eval functions are intended for internal use only and are accessed through the API, which sets the `core-async` engine when no engine is provided, the decision was made to remove the behavior of having a default engine at applicative eval functions.