### PR TITLE
Stop using core.async internals and rely on its interfaces

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -24,6 +24,7 @@
 
   :profiles {:uberjar {:aot :all}
              :dev     {:source-paths ["dev"]
+                       :jvm-opts ["-Dclojure.core.async.go-checking=true"]
                        :plugins [[com.github.clojure-lsp/lein-clojure-lsp "0.1.1"]
                                  [com.github.clj-kondo/lein-clj-kondo "0.1.1"]]
                        :dependencies [[nubank/matcher-combinators "3.1.4"]

--- a/test/nodely/engine/core_async/lazy_scheduling_test.clj
+++ b/test/nodely/engine/core_async/lazy_scheduling_test.clj
@@ -93,22 +93,11 @@
                                                       {:data "data"}))))
                         :c (>leaf (+ ?a ?b))})
 
-(def env-with-blocking-tag {:a (>leaf (Thread/currentThread))
-                            :b (blocking (>leaf (Thread/currentThread)))
-                            :a-name (>leaf (.getName ?a))
-                            :b-name (>leaf (.getName ?b))
-                            :c (>leaf (str ?a-name " " ?b-name))})
-
-(def env-with-nine-sleeps {:a (blocking (>leaf (do (Thread/sleep 1000) :a)))
-                           :b (blocking (>leaf (do (Thread/sleep 1000) :b)))
-                           :c (blocking (>leaf (do (Thread/sleep 1000) :c)))
-                           :d (blocking (>leaf (do (Thread/sleep 1000) :d)))
-                           :e (blocking (>leaf (do (Thread/sleep 1000) :e)))
-                           :f (blocking (>leaf (do (Thread/sleep 1000) :f)))
-                           :g (blocking (>leaf (do (Thread/sleep 1000) :g)))
-                           :h (blocking (>leaf (do (Thread/sleep 1000) :h)))
-                           :i (blocking (>leaf (do (Thread/sleep 1000) :i)))
-                           :z (>leaf (into #{} [?a ?b ?c ?d ?e ?f ?g ?h ?i]))})
+(def env-with-blocking-take {:a (>leaf (async/chan 1))
+                             :b (blocking (>leaf (async/>!! ?a :test)))
+                             :c (>leaf (try (async/<!! ?a)
+                                            (catch Throwable t t)))
+                             :d (>leaf (vector ?b ?c))})
 
 (deftest eval-env
   (testing "async response is equal to sync response"
@@ -204,19 +193,12 @@
                 (nasync/eval-key env (rand-nth (keys env)))
                 true))
 
-(deftest blocking-eval-test
-  (testing "eval of a blocking tagged node will happen in the `async-thread-macro` worker pool"
-    (is (match? #"async-thread-macro-\d+"
-                (nasync/eval-key env-with-blocking-tag :b-name)))
-    (is (match? #"async-dispatch-\d+"
-                (nasync/eval-key env-with-blocking-tag :a-name)))))
-
-(deftest thread-sleeping-test-proves-thread-works-how-we-expect
-  (testing "actually only 8 threads in the async dispatch worker pool"
-    (is (match? 8
-                @@#'clojure.core.async.impl.exec.threadpool/pool-size)))
-  (testing "when we have 9 1-second blocking nodes in one environment, it can run in fewer than 2 seconds"
-    (testing "async version runs parallel when option is neglected"
-      (let [[nanosec-async _] (time-body (nasync/eval-key env-with-nine-sleeps :z))]
-        (is (match? (matchers/within-delta 1000000000 1000000000)
-                    nanosec-async))))))
+(deftest blocking-tagging-test
+  (testing "about the blocking tag"
+    (testing "go-checking system property is set"
+      (is (Boolean/getBoolean "clojure.core.async.go-checking")))
+    (testing "eval of an env with blocking ops in dispatch worker pool provokes exceptions, evaling same ops in threads doesn't"
+      (is (match? [true java.lang.IllegalStateException]
+                  (update (nasync/eval-key env-with-blocking-take :d)
+                          1
+                          class))))))


### PR DESCRIPTION
- Blocking tag is relevant for tools like core.async
- Instead of looking at core.async internal state, use documentated interface points
- Enable go-checking in dev and test so that use of blocking ops inside the dispatch worker pool throws. Also examine that a blocking tagged leaf DOES NOT throw on similar blocking ops.