### PR TITLE
Fix using core.async internals in the applicative engine too

### DIFF
--- a/test/nodely/engine/applicative_test.clj
+++ b/test/nodely/engine/applicative_test.clj
@@ -255,10 +255,10 @@
 
 (defspec does-not-blow-up-spec
   (prop/for-all [env (fixtures/env-gen {})]
-    (applicative/eval-key env
-                          (rand-nth (keys env))
-                          {::applicative/context core-async/context})
-    true))
+                (applicative/eval-key env
+                                      (rand-nth (keys env))
+                                      {::applicative/context core-async/context})
+                true))
 
 (deftest eval-key-contextual-test
   (testing "eval node async for interesting example"


### PR DESCRIPTION
Per #48 we were using core.async internals in the applicative engine's tests.

We use the same go-checking strategy to excise the use of core.async internals. However, because the applicative engine special cases when the returned value of a leaf is in the class of the context the engine is evaluating with, and, special cases when the value of a leaf is an exception.