### PR TITLE
schedule key in context

### DIFF
--- a/src/nodely/engine/applicative.clj
+++ b/src/nodely/engine/applicative.clj
@@ -90,6 +90,13 @@
     (app/fmap (partial async/put! chan) contextual-v)
     chan))
 
+(defn schedule
+  "schedule key k to be evaluated within env, returns lazy environment"
+  [env k opts]
+  (let [lazy-env (lazy-env/lazy-env env eval-in-context opts)
+        _ (get lazy-env k)]
+    lazy-env))
+
 (defn eval
   [env k opts]
   (let [lazy-env (lazy-env/lazy-env env eval-in-context opts)]

--- a/test/nodely/engine/applicative_test.clj
+++ b/test/nodely/engine/applicative_test.clj
@@ -289,3 +289,9 @@
     promesa/context     java.util.concurrent.CompletableFuture
     core-async/context  clojure.core.async.impl.channels.ManyToManyChannel
     synchronous/context nodely.engine.applicative.synchronous.Box))
+
+(deftest schedule
+  (let [lazy-env (applicative/schedule {:a (data/value 1)} :a {::applicative/context core-async/context})]
+    (is (= nodely.engine.lazy_env.LazySchedulingEnvironment  (type lazy-env)))
+    (is (= (data/value 1) (async/<!! (get lazy-env :a))))))
+


### PR DESCRIPTION
Schedule returns a lazy-environment with key k scheduled and running. The lazy-environment works like a map and when you `get` keys from it, it returns a value node encapsulated within the context it is being evaluated on (channel, promesa, virtual future etc.)