### PR TITLE
fix: collect expression symbols with symbol?

### DIFF
--- a/src/nodely/syntax.clj
+++ b/src/nodely/syntax.clj
@@ -6,8 +6,12 @@
    [nodely.data :as data]))
 
 (defn- expression-symbols
+  "Collect symbols that appear as leaves in `expr`.
+
+  Uses `symbol?` (not `(complement seqable?)`) so non-symbol atoms such as
+  numbers, keywords, and strings are excluded before later `?`-prefix filtering."
   [expr]
-  (set (filter (complement seqable?) (tree-seq seqable? seq expr))))
+  (set (filter symbol? (tree-seq seqable? seq expr))))
 
 (defn- question-mark->keyword
   [s]

--- a/test/nodely/syntax_test.clj
+++ b/test/nodely/syntax_test.clj
@@ -218,3 +218,13 @@
                         :process-node #::data{:type :value
                                               :value ifn?}}
                 (>sequence inc ?foo/bar)))))
+
+(deftest expression-symbols-collects-only-symbols
+  ;; #59: leaves must be filtered with `symbol?`, not `(complement seqable?)`,
+  ;; so non-symbol atoms are never treated as `?`-inputs.
+  (testing "numbers and keywords in an expression do not become inputs"
+    (is (match? #::data{:type :leaf :inputs #{:x} :fn ifn?}
+                (>leaf (+ ?x 1 :not-an-input)))))
+  (testing "only `?`-prefixed symbols become inputs"
+    (is (match? #::data{:type :leaf :inputs #{:y} :fn ifn?}
+                (>leaf (str ?y "suffix"))))))


### PR DESCRIPTION
## Summary
- Change `expression-symbols` to filter with `symbol?` instead of `(complement seqable?)`.
- Document why, and add regression tests that numbers/keywords in `>leaf` expressions do not become inputs.

## Why
`?`-input discovery only needs symbols. Filtering non-seqable leaves also kept numbers, keywords, and strings in the candidate set until a later string prefix check — `symbol?` answers issue #59 directly and makes the intent obvious.

Fixes #59

## Test plan
- [x] `lein test nodely.syntax-test` (0 failures)
- [ ] Full suite / CI


---

— Felipe Fernandes · Systems & Agentic AI Engineer
https://github.com/felipeofdev-ai · https://felipeofdev-ai.github.io/

Made with [Cursor](https://cursor.com)